### PR TITLE
A32 Vector Rounding modes VRINTN, VRINTX, VRINTA, VRINTZ, VRINTM, VRINTP

### DIFF
--- a/src/dynarmic/frontend/A32/decoder/asimd.inc
+++ b/src/dynarmic/frontend/A32/decoder/asimd.inc
@@ -120,12 +120,12 @@ INST(asimd_VMOVN,           "VMOVN",                    "111100111D11zz10dddd001
 INST(asimd_VQMOVUN,         "VQMOVUN",                  "111100111D11zz10dddd001001M0mmmm") // ASIMD
 INST(asimd_VQMOVN,          "VQMOVN",                   "111100111D11zz10dddd00101oM0mmmm") // ASIMD
 INST(asimd_VSHLL_max,       "VSHLL_max",                "111100111D11zz10dddd001100M0mmmm") // ASIMD
-INST(arm_UDF,               "UNALLOCATED (VRINTN)",     "111100111-11--10----01000--0----")
-INST(arm_UDF,               "UNALLOCATED (VRINTX)",     "111100111-11--10----01001--0----")
-INST(arm_UDF,               "UNALLOCATED (VRINTA)",     "111100111-11--10----01010--0----")
-INST(arm_UDF,               "UNALLOCATED (VRINTZ)",     "111100111-11--10----01011--0----")
-INST(arm_UDF,               "UNALLOCATED (VRINTM)",     "111100111-11--10----01101--0----")
-INST(arm_UDF,               "UNALLOCATED (VRINTP)",     "111100111-11--10----01111--0----")
+INST(asimd_VRINTN,          "VRINTN",                   "111100111D11zz10dddd01000QM0mmmm") // v8
+INST(asimd_VRINTX,          "VRINTX",                   "111100111D11zz10dddd01001QM0mmmm") // v8
+INST(asimd_VRINTA,          "VRINTA",                   "111100111D11zz10dddd01010QM0mmmm") // v8
+INST(asimd_VRINTZ,          "VRINTZ",                   "111100111D11zz10dddd01011QM0mmmm") // v8
+INST(asimd_VRINTM,          "VRINTM",                   "111100111D11zz10dddd01101QM0mmmm") // v8
+INST(asimd_VRINTP,          "VRINTP",                   "111100111D11zz10dddd01111QM0mmmm") // v8
 INST(asimd_VCVT_half,       "VCVT (half-precision)",    "111100111D11zz10dddd011o00M0mmmm") // ASIMD
 INST(arm_UDF,               "UNALLOCATED",              "111100111-11--10----011-01-0----") // ASIMD
 INST(arm_UDF,               "UNALLOCATED (VCVTA)",      "111100111-11--11----0000---0----")

--- a/src/dynarmic/frontend/A32/translate/impl/asimd_two_regs_misc.cpp
+++ b/src/dynarmic/frontend/A32/translate/impl/asimd_two_regs_misc.cpp
@@ -608,6 +608,132 @@ bool TranslatorVisitor::asimd_VSHLL_max(bool D, size_t sz, size_t Vd, bool M, si
     return true;
 }
 
+bool TranslatorVisitor::asimd_VRINTN(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    if (sz == 0b00 || sz == 0b11) {
+        return UndefinedInstruction();
+    }
+
+    const size_t esize = 8U << sz;
+    const auto rounding_mode = FP::RoundingMode::ToNearest_TieEven;
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto operand = ir.GetVector(m);
+    const auto result = ir.FPVectorRoundInt(esize, operand, rounding_mode, false, false);
+
+    ir.SetVector(d, result);
+    return true;
+}
+
+bool TranslatorVisitor::asimd_VRINTX(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    if (sz == 0b00 || sz == 0b11) {
+        return UndefinedInstruction();
+    }
+
+    const size_t esize = 8U << sz;
+    const auto rounding_mode = FP::RoundingMode::ToNearest_TieEven;
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto operand = ir.GetVector(m);
+    const auto result = ir.FPVectorRoundInt(esize, operand, rounding_mode, true, false);
+
+    ir.SetVector(d, result);
+    return true;
+}
+
+bool TranslatorVisitor::asimd_VRINTA(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    if (sz == 0b00 || sz == 0b11) {
+        return UndefinedInstruction();
+    }
+
+    const size_t esize = 8U << sz;
+    const auto rounding_mode = FP::RoundingMode::ToNearest_TieAwayFromZero;
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto operand = ir.GetVector(m);
+    const auto result = ir.FPVectorRoundInt(esize, operand, rounding_mode, false, false);
+
+    ir.SetVector(d, result);
+    return true;
+}
+
+bool TranslatorVisitor::asimd_VRINTZ(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    if (sz == 0b00 || sz == 0b11) {
+        return UndefinedInstruction();
+    }
+
+    const size_t esize = 8U << sz;
+    const auto rounding_mode = FP::RoundingMode::TowardsZero;
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto operand = ir.GetVector(m);
+    const auto result = ir.FPVectorRoundInt(esize, operand, rounding_mode, false, false);
+
+    ir.SetVector(d, result);
+    return true;
+}
+
+bool TranslatorVisitor::asimd_VRINTM(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    if (sz == 0b00 || sz == 0b11) {
+        return UndefinedInstruction();
+    }
+
+    const size_t esize = 8U << sz;
+    const auto rounding_mode = FP::RoundingMode::TowardsMinusInfinity;
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto operand = ir.GetVector(m);
+    const auto result = ir.FPVectorRoundInt(esize, operand, rounding_mode, false, false);
+
+    ir.SetVector(d, result);
+    return true;
+}
+
+bool TranslatorVisitor::asimd_VRINTP(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm) {
+    if (Q && (Common::Bit<0>(Vd) || Common::Bit<0>(Vm))) {
+        return UndefinedInstruction();
+    }
+
+    if (sz == 0b00 || sz == 0b11) {
+        return UndefinedInstruction();
+    }
+
+    const size_t esize = 8U << sz;
+    const auto rounding_mode = FP::RoundingMode::TowardsPlusInfinity;
+    const auto d = ToVector(Q, Vd, D);
+    const auto m = ToVector(Q, Vm, M);
+
+    const auto operand = ir.GetVector(m);
+    const auto result = ir.FPVectorRoundInt(esize, operand, rounding_mode, false, false);
+
+    ir.SetVector(d, result);
+    return true;
+}
+
 bool TranslatorVisitor::asimd_VCVT_half(bool D, size_t sz, size_t Vd, bool half_to_single, bool M, size_t Vm) {
     if (sz != 0b01) {
         return UndefinedInstruction();

--- a/src/dynarmic/frontend/A32/translate/impl/translate.h
+++ b/src/dynarmic/frontend/A32/translate/impl/translate.h
@@ -940,6 +940,12 @@ struct TranslatorVisitor final {
     bool asimd_VQMOVUN(bool D, size_t sz, size_t Vd, bool M, size_t Vm);
     bool asimd_VQMOVN(bool D, size_t sz, size_t Vd, bool op, bool M, size_t Vm);
     bool asimd_VSHLL_max(bool D, size_t sz, size_t Vd, bool M, size_t Vm);
+    bool asimd_VRINTN(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm);
+    bool asimd_VRINTX(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm);
+    bool asimd_VRINTA(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm);
+    bool asimd_VRINTZ(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm);
+    bool asimd_VRINTM(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm);
+    bool asimd_VRINTP(bool D, size_t sz, size_t Vd, bool Q, bool M, size_t Vm);
     bool asimd_VCVT_half(bool D, size_t sz, size_t Vd, bool op, bool M, size_t Vm);
     bool asimd_VRECPE(bool D, size_t sz, size_t Vd, bool F, bool Q, bool M, size_t Vm);
     bool asimd_VRSQRTE(bool D, size_t sz, size_t Vd, bool F, bool Q, bool M, size_t Vm);


### PR DESCRIPTION
I'm not sure I did this correctly, let me know if this is all wrong. I was considering compressing them all into a single function and switching on the op to save some code, but I wasn't sure you wanted something like that.

How come the exact/inexact and fpcr_controlled states aren't output in the roundps/roundpd immediate?