### PR TITLE
Disassemble as vector of strings

### DIFF
--- a/src/dynarmic/backend/x64/a32_interface.cpp
+++ b/src/dynarmic/backend/x64/a32_interface.cpp
@@ -318,12 +318,12 @@ void Jit::LoadContext(const Context& ctx) {
 }
 
 void Jit::DumpDisassembly() const {
-    const size_t size = (const char*)impl->block_of_code.getCurr() - (const char*)impl->block_of_code.GetCodeBegin();
+    const size_t size = reinterpret_cast<const char*>(impl->block_of_code.getCurr()) - reinterpret_cast<const char*>(impl->block_of_code.GetCodeBegin());
     Common::DumpDisassembledX64(impl->block_of_code.GetCodeBegin(), size);
 }
 
-std::vector<std::string> Jit::Disassemble() {
-    const size_t size = (const char*)impl->block_of_code.getCurr() - (const char*)impl->block_of_code.GetCodeBegin();
+std::vector<std::string> Jit::Disassemble() const {
+    const size_t size = reinterpret_cast<const char*>(impl->block_of_code.getCurr()) - reinterpret_cast<const char*>(impl->block_of_code.GetCodeBegin());
     return Common::DisassembleX64(impl->block_of_code.GetCodeBegin(), size);
 }
 }  // namespace Dynarmic::A32

--- a/src/dynarmic/backend/x64/a32_interface.cpp
+++ b/src/dynarmic/backend/x64/a32_interface.cpp
@@ -322,4 +322,8 @@ void Jit::DumpDisassembly() const {
     Common::DumpDisassembledX64(impl->block_of_code.GetCodeBegin(), size);
 }
 
+std::vector<std::string> Jit::Disassemble() {
+    const size_t size = (const char*)impl->block_of_code.getCurr() - (const char*)impl->block_of_code.GetCodeBegin();
+    return Common::DisassembleX64(impl->block_of_code.GetCodeBegin(), size);
+}
 }  // namespace Dynarmic::A32

--- a/src/dynarmic/backend/x64/a64_interface.cpp
+++ b/src/dynarmic/backend/x64/a64_interface.cpp
@@ -200,12 +200,12 @@ public:
     }
 
     void DumpDisassembly() const {
-        const size_t size = (const char*)block_of_code.getCurr() - (const char*)block_of_code.GetCodeBegin();
+        const size_t size = reinterpret_cast<const char*>(block_of_code.getCurr()) - reinterpret_cast<const char*>(block_of_code.GetCodeBegin());
         Common::DumpDisassembledX64(block_of_code.GetCodeBegin(), size);
     }
 
-    std::vector<std::string> Disassemble() {
-        const size_t size = (const char*)block_of_code.getCurr() - (const char*)block_of_code.GetCodeBegin();
+    std::vector<std::string> Disassemble() const {
+        const size_t size = reinterpret_cast<const char*>(block_of_code.getCurr()) - reinterpret_cast<const char*>(block_of_code.GetCodeBegin());
         return Common::DisassembleX64(block_of_code.GetCodeBegin(), size);
     }
 
@@ -407,7 +407,7 @@ void Jit::DumpDisassembly() const {
     return impl->DumpDisassembly();
 }
 
-std::vector<std::string> Jit::Disassemble() {
+std::vector<std::string> Jit::Disassemble() const {
     return impl->Disassemble();
 }
 

--- a/src/dynarmic/backend/x64/a64_interface.cpp
+++ b/src/dynarmic/backend/x64/a64_interface.cpp
@@ -204,6 +204,11 @@ public:
         Common::DumpDisassembledX64(block_of_code.GetCodeBegin(), size);
     }
 
+    std::vector<std::string> Disassemble() {
+        const size_t size = (const char*)block_of_code.getCurr() - (const char*)block_of_code.GetCodeBegin();
+        return Common::DisassembleX64(block_of_code.GetCodeBegin(), size);
+    }
+
 private:
     static CodePtr GetCurrentBlockThunk(void* thisptr) {
         Jit::Impl* this_ = static_cast<Jit::Impl*>(thisptr);
@@ -400,6 +405,10 @@ bool Jit::IsExecuting() const {
 
 void Jit::DumpDisassembly() const {
     return impl->DumpDisassembly();
+}
+
+std::vector<std::string> Jit::Disassemble() {
+    return impl->Disassemble();
 }
 
 }  // namespace Dynarmic::A64

--- a/src/dynarmic/common/fp/unpacked.h
+++ b/src/dynarmic/common/fp/unpacked.h
@@ -46,7 +46,7 @@ constexpr FPUnpacked ToNormalized(bool sign, int exponent, u64 value) {
     const int highest_bit = Common::HighestSetBit(value);
     const int offset = static_cast<int>(normalized_point_position) - highest_bit;
     value <<= offset;
-    exponent -= offset - normalized_point_position;
+    exponent -= offset - static_cast<int>(normalized_point_position);
     return {sign, exponent, value};
 }
 

--- a/src/dynarmic/common/x64_disassemble.cpp
+++ b/src/dynarmic/common/x64_disassemble.cpp
@@ -32,8 +32,6 @@ void DumpDisassembledX64(const void* ptr, size_t size) {
     }
 }
 
-// Disassemble `size' bytes from `ptr' and return the disassembled lines as a vector
-// of strings.
 std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_t size) {
     std::vector<std::string> result;
     ZydisDecoder decoder;
@@ -45,7 +43,6 @@ std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_
     size_t offset = 0;
     ZydisDecodedInstruction instruction;
     while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, static_cast<const char *>(ptr) + offset, size - offset, &instruction))) {
-
         char buffer[256];
         ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), reinterpret_cast<u64>(ptr) + offset);
         
@@ -56,5 +53,4 @@ std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_
 
     return result;
 }
-
 }  // namespace Dynarmic::Common

--- a/src/dynarmic/common/x64_disassemble.cpp
+++ b/src/dynarmic/common/x64_disassemble.cpp
@@ -45,7 +45,6 @@ std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_
     size_t offset = 0;
     ZydisDecodedInstruction instruction;
     while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, (const char*)ptr + offset, size - offset, &instruction))) {
-        fmt::print("{:016x}  ", (u64)ptr + offset);
 
         char buffer[256];
         ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), (u64)ptr + offset);

--- a/src/dynarmic/common/x64_disassemble.cpp
+++ b/src/dynarmic/common/x64_disassemble.cpp
@@ -21,11 +21,11 @@ void DumpDisassembledX64(const void* ptr, size_t size) {
 
     size_t offset = 0;
     ZydisDecodedInstruction instruction;
-    while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, (const char*)ptr + offset, size - offset, &instruction))) {
+    while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, static_cast<const char*>(ptr) + offset, size - offset, &instruction))) {
         fmt::print("{:016x}  ", (u64)ptr + offset);
 
         char buffer[256];
-        ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), (u64)ptr + offset);
+        ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), reinterpret_cast<u64>(ptr) + offset);
         puts(buffer);
 
         offset += instruction.length;
@@ -44,10 +44,10 @@ std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_
 
     size_t offset = 0;
     ZydisDecodedInstruction instruction;
-    while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, (const char*)ptr + offset, size - offset, &instruction))) {
+    while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, static_cast<const char *>(ptr) + offset, size - offset, &instruction))) {
 
         char buffer[256];
-        ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), (u64)ptr + offset);
+        ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), reinterpret_cast<u64>(ptr) + offset);
         
         result.push_back(fmt::format("{:016x}  {}", (u64)ptr + offset, buffer));
 

--- a/src/dynarmic/common/x64_disassemble.cpp
+++ b/src/dynarmic/common/x64_disassemble.cpp
@@ -32,7 +32,7 @@ void DumpDisassembledX64(const void* ptr, size_t size) {
     }
 }
 
-std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_t size) {
+std::vector<std::string> DisassembleX64(const void* ptr, size_t size) {
     std::vector<std::string> result;
     ZydisDecoder decoder;
     ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_ADDRESS_WIDTH_64);
@@ -42,10 +42,10 @@ std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_
 
     size_t offset = 0;
     ZydisDecodedInstruction instruction;
-    while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, static_cast<const char *>(ptr) + offset, size - offset, &instruction))) {
+    while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, static_cast<const char*>(ptr) + offset, size - offset, &instruction))) {
         char buffer[256];
         ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), reinterpret_cast<u64>(ptr) + offset);
-        
+
         result.push_back(fmt::format("{:016x}  {}", (u64)ptr + offset, buffer));
 
         offset += instruction.length;

--- a/src/dynarmic/common/x64_disassemble.cpp
+++ b/src/dynarmic/common/x64_disassemble.cpp
@@ -32,4 +32,30 @@ void DumpDisassembledX64(const void* ptr, size_t size) {
     }
 }
 
+// Disassemble `size' bytes from `ptr' and return the disassembled lines as a vector
+// of strings.
+std::vector<std::string> Dynarmic::Common::DisassembleX64(const void* ptr, size_t size) {
+    std::vector<std::string> result;
+    ZydisDecoder decoder;
+    ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_ADDRESS_WIDTH_64);
+
+    ZydisFormatter formatter;
+    ZydisFormatterInit(&formatter, ZYDIS_FORMATTER_STYLE_INTEL);
+
+    size_t offset = 0;
+    ZydisDecodedInstruction instruction;
+    while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, (const char*)ptr + offset, size - offset, &instruction))) {
+        fmt::print("{:016x}  ", (u64)ptr + offset);
+
+        char buffer[256];
+        ZydisFormatterFormatInstruction(&formatter, &instruction, buffer, sizeof(buffer), (u64)ptr + offset);
+        
+        result.push_back(fmt::format("{:016x}  {}", (u64)ptr + offset, buffer));
+
+        offset += instruction.length;
+    }
+
+    return result;
+}
+
 }  // namespace Dynarmic::Common

--- a/src/dynarmic/common/x64_disassemble.h
+++ b/src/dynarmic/common/x64_disassemble.h
@@ -5,9 +5,11 @@
 
 #pragma once
 
-#include "dynarmic/common/common_types.h"
+
 #include <vector>
 #include <string>
+
+#include "dynarmic/common/common_types.h"
 
 namespace Dynarmic::Common {
 

--- a/src/dynarmic/common/x64_disassemble.h
+++ b/src/dynarmic/common/x64_disassemble.h
@@ -5,9 +5,8 @@
 
 #pragma once
 
-
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "dynarmic/common/common_types.h"
 

--- a/src/dynarmic/common/x64_disassemble.h
+++ b/src/dynarmic/common/x64_disassemble.h
@@ -6,9 +6,12 @@
 #pragma once
 
 #include "dynarmic/common/common_types.h"
+#include <vector>
+#include <string>
 
 namespace Dynarmic::Common {
 
+std::vector<std::string> DisassembleX64(const void* ptr, size_t size);
 void DumpDisassembledX64(const void* ptr, size_t size);
 
 }  // namespace Dynarmic::Common

--- a/src/dynarmic/common/x64_disassemble.h
+++ b/src/dynarmic/common/x64_disassemble.h
@@ -11,7 +11,10 @@
 
 namespace Dynarmic::Common {
 
-std::vector<std::string> DisassembleX64(const void* ptr, size_t size);
 void DumpDisassembledX64(const void* ptr, size_t size);
-
+/**
+ * Disassemble `size' bytes from `ptr' and return the disassembled lines as a vector
+ * of strings.
+ */
+std::vector<std::string> DisassembleX64(const void* ptr, size_t size);
 }  // namespace Dynarmic::Common

--- a/src/dynarmic/interface/A32/a32.h
+++ b/src/dynarmic/interface/A32/a32.h
@@ -92,7 +92,11 @@ public:
     /// Debugging: Dump a disassembly all compiled code to the console.
     void DumpDisassembly() const;
 
-    std::vector<std::string> Disassemble();
+    /* 
+     * Disassemble the instructions following the current pc and return
+     * the resulting instructions as a vector of their string representations.
+     */
+    std::vector<std::string> Disassemble() const;
 
 private:
     bool is_executing = false;

--- a/src/dynarmic/interface/A32/a32.h
+++ b/src/dynarmic/interface/A32/a32.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "dynarmic/interface/A32/config.h"
 
@@ -90,6 +91,8 @@ public:
 
     /// Debugging: Dump a disassembly all compiled code to the console.
     void DumpDisassembly() const;
+
+    std::vector<std::string> Disassemble();
 
 private:
     bool is_executing = false;

--- a/src/dynarmic/interface/A32/a32.h
+++ b/src/dynarmic/interface/A32/a32.h
@@ -92,7 +92,7 @@ public:
     /// Debugging: Dump a disassembly all compiled code to the console.
     void DumpDisassembly() const;
 
-    /* 
+    /**
      * Disassemble the instructions following the current pc and return
      * the resulting instructions as a vector of their string representations.
      */

--- a/src/dynarmic/interface/A64/a64.h
+++ b/src/dynarmic/interface/A64/a64.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "dynarmic/interface/A64/config.h"
 
@@ -116,6 +117,8 @@ public:
 
     /// Debugging: Dump a disassembly all of compiled code to the console.
     void DumpDisassembly() const;
+
+    std::vector<std::string> Disassemble();
 
 private:
     struct Impl;

--- a/src/dynarmic/interface/A64/a64.h
+++ b/src/dynarmic/interface/A64/a64.h
@@ -118,7 +118,11 @@ public:
     /// Debugging: Dump a disassembly all of compiled code to the console.
     void DumpDisassembly() const;
 
-    std::vector<std::string> Disassemble();
+    /* 
+     * Disassemble the instructions following the current pc and return
+     * the resulting instructions as a vector of their string representations.
+     */
+    std::vector<std::string> Disassemble() const;
 
 private:
     struct Impl;


### PR DESCRIPTION
Adds the ability to get the disassembly that would've before been dumped to stdout as a vector of strings. I'm unfamiliar with this project so if I just walked into a minefield by copying the "dump" function don't hesitate to let me know. Also let me know if there's a more idiomatic approach here.

This information will be pulled into the [debugger I'm writing for yuzu](https://github.com/Avuxo/yuzu/tree/beato-debugger).  I tested it by linking against this version with yuzu and confirmed disassembly is output as expected.