### PR TITLE
disassembler_thumb: fix formatting issues with fmt 8.1.x

### DIFF
--- a/src/dynarmic/frontend/A32/disassembler/disassembler_thumb.cpp
+++ b/src/dynarmic/frontend/A32/disassembler/disassembler_thumb.cpp
@@ -285,7 +285,7 @@ public:
             // Sanity note: Here imm8.Bit<0>() is guaranteed to be == 1. (imm8 can never be 0bxxxx0000)
             return std::make_tuple(imm8.Bit<3>() == firstcond0 ? "t" : "e", imm8.Bit<2>() == firstcond0 ? "t" : "e", imm8.Bit<1>() == firstcond0 ? "t" : "e");
         }();
-        return fmt::format("it{}{}{} {}", x, y, z, firstcond);
+        return fmt::format("it{}{}{} {}", x, y, z, CondToString(firstcond));
     }
 
     std::string thumb16_SXTH(Reg m, Reg d) {


### PR DESCRIPTION
`fmt` 8.1.0 added more formatting checks and `Cond` can't be formatted directly now.

This shouldn't break compatibilities with `fmt` < `8.1.0` though, as I think it is very likely it was an accident that it passed compilation on any `fmt` version that is lower than `8.1.0` since `Cond` does not implement `operator<<` for `std::ostream` or `fmt::formatter`.

------

For an example of what error is thrown, here it is:

```
In file included from /app/include/fmt/format.h:48,
                 from /run/build/yuzu/externals/dynarmic/src/dynarmic/frontend/A32/disassembler/disassembler_thumb.cpp:9:
/app/include/fmt/core.h: In instantiation of ‘constexpr decltype (ctx.begin()) fmt::v8::detail::parse_format_specs(ParseContext&) [with T = Dynarmic::IR::Cond; ParseContext = fmt::v8::detail::compile_parse_context<char, fmt::v8::detail::error_handler>; decltype (ctx.begin()) = const char*]’:
/app/include/fmt/core.h:2893:9:   required from ‘constexpr fmt::v8::detail::format_string_checker<Char, ErrorHandler, Args>::format_string_checker(fmt::v8::basic_string_view<Char>, ErrorHandler) [with Char = char; ErrorHandler = fmt::v8::detail::error_handler; Args = {const char*, const char*, const char*, Dynarmic::IR::Cond}]’
/run/build/yuzu/externals/dynarmic/src/dynarmic/frontend/A32/disassembler/disassembler_thumb.cpp:288:27:   required from here
/run/build/yuzu/externals/dynarmic/src/dynarmic/frontend/A32/disassembler/disassembler_thumb.cpp:288:27:   in ‘constexpr’ expansion of ‘fmt::v8::basic_format_string<char, const char* const&, const char* const&, const char* const&, const Dynarmic::IR::Cond&>("it{}{}{} {}")’
/app/include/fmt/core.h:2659:12: error: use of deleted function ‘fmt::v8::detail::fallback_formatter<T, Char, Enable>::fallback_formatter() [with T = Dynarmic::IR::Cond; Char = char; Enable = void]’
 2659 |   auto f = conditional_t<has_formatter<mapped_type, context>::value,
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2660 |                          formatter<mapped_type, char_type>,
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2661 |                          fallback_formatter<T, char_type>>();
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/app/include/fmt/core.h:1027:3: note: declared here
 1027 |   fallback_formatter() = delete;
      |   ^~~~~~~~~~~~~~~~~~
/app/include/fmt/core.h: In instantiation of ‘constexpr fmt::v8::detail::value<Context> fmt::v8::detail::make_arg(T&&) [with bool IS_PACKED = true; Context = fmt::v8::basic_format_context<fmt::v8::appender, char>; fmt::v8::detail::type <anonymous> = fmt::v8::detail::type::custom_type; T = const Dynarmic::IR::Cond&; typename std::enable_if<IS_PACKED, int>::type <anonymous> = 0]’:
/app/include/fmt/core.h:1842:77:   required from ‘constexpr fmt::v8::format_arg_store<Context, Args>::format_arg_store(T&& ...) [with T = {const char* const&, const char* const&, const char* const&, const Dynarmic::IR::Cond&}; Context = fmt::v8::basic_format_context<fmt::v8::appender, char>; Args = {const char*, const char*, const char*, Dynarmic::IR::Cond}]’
/app/include/fmt/core.h:1859:38:   required from ‘constexpr fmt::v8::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<Args>::type>::type ...> fmt::v8::make_format_args(Args&& ...) [with Context = fmt::v8::basic_format_context<fmt::v8::appender, char>; Args = {const char* const&, const char* const&, const char* const&, const Dynarmic::IR::Cond&}]’
/app/include/fmt/core.h:3106:44:   required from ‘std::string fmt::v8::format(fmt::v8::format_string<T ...>, T&& ...) [with T = {const char* const&, const char* const&, const char* const&, const Dynarmic::IR::Cond&}; std::string = std::__cxx11::basic_string<char>; fmt::v8::format_string<T ...> = fmt::v8::basic_format_string<char, const char* const&, const char* const&, const char* const&, const Dynarmic::IR::Cond&>]’
/run/build/yuzu/externals/dynarmic/src/dynarmic/frontend/A32/disassembler/disassembler_thumb.cpp:288:27:   required from here
/app/include/fmt/core.h:1715:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1715 |       formattable,
      |       ^~~~~~~~~~~
/app/include/fmt/core.h:1715:7: note: ‘formattable’ evaluates to false
```