### PR TITLE
exclusive_monitor: Add missing call to Unlock(), and yield thread instead of busy waiting

### DIFF
--- a/src/dynarmic/backend/x64/exclusive_monitor.cpp
+++ b/src/dynarmic/backend/x64/exclusive_monitor.cpp
@@ -42,6 +42,7 @@ bool ExclusiveMonitor::CheckAndClear(size_t processor_id, VAddr address) {
             other_address = INVALID_EXCLUSIVE_ADDRESS;
         }
     }
+    Unlock();
     return true;
 }
 

--- a/src/dynarmic/backend/x64/exclusive_monitor.cpp
+++ b/src/dynarmic/backend/x64/exclusive_monitor.cpp
@@ -6,6 +6,7 @@
 #include "dynarmic/interface/exclusive_monitor.h"
 
 #include <algorithm>
+#include <thread>
 
 #include "dynarmic/common/assert.h"
 
@@ -21,7 +22,9 @@ size_t ExclusiveMonitor::GetProcessorCount() const {
 }
 
 void ExclusiveMonitor::Lock() {
-    while (is_locked.test_and_set(std::memory_order_acquire)) {}
+    while (is_locked.test_and_set(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
 }
 
 void ExclusiveMonitor::Unlock() {


### PR DESCRIPTION
This was uncovered by profiling `Pokemon Legends Arceus` in yuzu Emulator.

Surprisingly, the missing call to `Unlock()` in `CheckAndClear()` did not cause deadlock, it did, however, create extra contention over the monitor's lock.

Adding the call to `Unlock()` helped with the performance in the game and reduced the CPU time spent in the `Lock()` method, with further improvements seen by yielding the thread instead of busy waiting. 

Please let me know if any of this was specifically designed to behave this way.

Here is the profiling data from  `Pokemon Legends Arceus` used to validate the changes. These were taken at roughly the same instance in-game, at the intro to Jubilife village, within run-to-run variance

No Unlock() |  Unlock() | Unlock() + yield
:-------------------------:|:-------------------------:|:-------------------------:
![no_unlock](https://user-images.githubusercontent.com/52414509/152479850-7dad83a5-5b8d-4591-8bc3-1669e4d87b58.PNG) | ![unlock](https://user-images.githubusercontent.com/52414509/152479865-5922791a-248e-4e57-ba64-8457829d4b96.PNG) |  ![unlock_yield](https://user-images.githubusercontent.com/52414509/152479872-0e4505b8-4e3a-479b-989f-a2a14584563f.PNG)
16.35% CPU usage, ~35 fps average | 9.17% CPU usage, ~40 fps average | 8.54% CPU usage, ~42 fps average

