### PR TITLE
Inline exclusive memory access operations

### DIFF
--- a/src/dynarmic/CMakeLists.txt
+++ b/src/dynarmic/CMakeLists.txt
@@ -301,6 +301,8 @@ if (ARCHITECTURE STREQUAL "x86_64")
         backend/x64/reg_alloc.cpp
         backend/x64/reg_alloc.h
         backend/x64/stack_layout.h
+        common/spin_lock_x64.cpp
+        common/spin_lock_x64.h
     )
 
     if ("A32" IN_LIST DYNARMIC_FRONTENDS)

--- a/src/dynarmic/CMakeLists.txt
+++ b/src/dynarmic/CMakeLists.txt
@@ -282,6 +282,7 @@ if (ARCHITECTURE STREQUAL "x86_64")
         backend/x64/emit_x64_crc32.cpp
         backend/x64/emit_x64_data_processing.cpp
         backend/x64/emit_x64_floating_point.cpp
+        backend/x64/emit_x64_memory.h
         backend/x64/emit_x64_packed.cpp
         backend/x64/emit_x64_saturation.cpp
         backend/x64/emit_x64_sm4.cpp

--- a/src/dynarmic/CMakeLists.txt
+++ b/src/dynarmic/CMakeLists.txt
@@ -289,6 +289,7 @@ if (ARCHITECTURE STREQUAL "x86_64")
         backend/x64/emit_x64_vector_saturation.cpp
         backend/x64/exception_handler.h
         backend/x64/exclusive_monitor.cpp
+        backend/x64/exclusive_monitor_friend.h
         backend/x64/host_feature.h
         backend/x64/hostloc.cpp
         backend/x64/hostloc.h

--- a/src/dynarmic/CMakeLists.txt
+++ b/src/dynarmic/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(dynarmic
     common/memory_pool.h
     common/safe_ops.h
     common/scope_exit.h
+    common/spin_lock.h
     common/string_util.h
     common/u128.cpp
     common/u128.h

--- a/src/dynarmic/backend/x64/a32_emit_x64.h
+++ b/src/dynarmic/backend/x64/a32_emit_x64.h
@@ -113,6 +113,10 @@ protected:
     void ExclusiveReadMemory(A32EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
     void ExclusiveWriteMemory(A32EmitContext& ctx, IR::Inst* inst);
+    template<std::size_t bitsize, auto callback>
+    void ExclusiveReadMemoryInlineUnsafe(A32EmitContext& ctx, IR::Inst* inst);
+    template<std::size_t bitsize, auto callback>
+    void ExclusiveWriteMemoryInlineUnsafe(A32EmitContext& ctx, IR::Inst* inst);
 
     // Terminal instruction emitters
     void EmitSetUpperLocationDescriptor(IR::LocationDescriptor new_location, IR::LocationDescriptor old_location);

--- a/src/dynarmic/backend/x64/a32_emit_x64.h
+++ b/src/dynarmic/backend/x64/a32_emit_x64.h
@@ -73,7 +73,7 @@ protected:
 
     std::map<std::tuple<size_t, int, int>, void (*)()> read_fallbacks;
     std::map<std::tuple<size_t, int, int>, void (*)()> write_fallbacks;
-    std::map<int, void (*)()> exclusive_write_fallbacks;
+    std::map<std::tuple<size_t, int, int>, void (*)()> exclusive_write_fallbacks;
     void GenFastmemFallbacks();
 
     const void* terminal_handler_pop_rsb_hint;
@@ -98,7 +98,8 @@ protected:
     struct FastmemPatchInfo {
         u64 resume_rip;
         u64 callback;
-        std::optional<DoNotFastmemMarker> marker;
+        DoNotFastmemMarker marker;
+        bool compile;
     };
     tsl::robin_map<u64, FastmemPatchInfo> fastmem_patch_info;
     std::set<DoNotFastmemMarker> do_not_fastmem;
@@ -115,9 +116,9 @@ protected:
     template<std::size_t bitsize, auto callback>
     void ExclusiveWriteMemory(A32EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
-    void ExclusiveReadMemoryInlineUnsafe(A32EmitContext& ctx, IR::Inst* inst);
+    void ExclusiveReadMemoryInline(A32EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
-    void ExclusiveWriteMemoryInlineUnsafe(A32EmitContext& ctx, IR::Inst* inst);
+    void ExclusiveWriteMemoryInline(A32EmitContext& ctx, IR::Inst* inst);
 
     // Terminal instruction emitters
     void EmitSetUpperLocationDescriptor(IR::LocationDescriptor new_location, IR::LocationDescriptor old_location);

--- a/src/dynarmic/backend/x64/a32_emit_x64.h
+++ b/src/dynarmic/backend/x64/a32_emit_x64.h
@@ -73,6 +73,7 @@ protected:
 
     std::map<std::tuple<size_t, int, int>, void (*)()> read_fallbacks;
     std::map<std::tuple<size_t, int, int>, void (*)()> write_fallbacks;
+    std::map<int, void (*)()> exclusive_write_fallbacks;
     void GenFastmemFallbacks();
 
     const void* terminal_handler_pop_rsb_hint;
@@ -97,7 +98,7 @@ protected:
     struct FastmemPatchInfo {
         u64 resume_rip;
         u64 callback;
-        DoNotFastmemMarker marker;
+        std::optional<DoNotFastmemMarker> marker;
     };
     tsl::robin_map<u64, FastmemPatchInfo> fastmem_patch_info;
     std::set<DoNotFastmemMarker> do_not_fastmem;

--- a/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
+++ b/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
@@ -442,8 +442,7 @@ void A32EmitX64::ExclusiveReadMemoryInlineUnsafe(A32EmitContext& ctx, IR::Inst* 
 
     const auto wrapped_fn = read_fallbacks[std::make_tuple(bitsize, vaddr.getIdx(), value.getIdx())];
 
-    Xbyak::Label abort, end;
-    bool require_abort_handling = false;
+    Xbyak::Label end;
 
     const auto src_ptr = r13 + vaddr;
 
@@ -463,14 +462,6 @@ void A32EmitX64::ExclusiveReadMemoryInlineUnsafe(A32EmitContext& ctx, IR::Inst* 
     code.mov(code.byte[r15 + offsetof(A32JitState, exclusive_state)], u8(1));
     code.mov(cmp_value_addr, Common::BitCast<u64>(GetExclusiveMonitorValuePointer(conf.global_monitor, conf.processor_id)));
     EmitWriteMemoryMov<bitsize>(code, cmp_value_addr, value);
-
-    if (require_abort_handling) {
-        code.SwitchToFarCode();
-        code.L(abort);
-        code.call(wrapped_fn);
-        code.jmp(end, code.T_NEAR);
-        code.SwitchToNearCode();
-    }
 
     ctx.reg_alloc.DefineValue(inst, value);
 }

--- a/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
+++ b/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
@@ -16,6 +16,7 @@
 #include "dynarmic/backend/x64/a32_emit_x64.h"
 #include "dynarmic/backend/x64/abi.h"
 #include "dynarmic/backend/x64/devirtualize.h"
+#include "dynarmic/backend/x64/exclusive_monitor_friend.h"
 #include "dynarmic/backend/x64/perf_map.h"
 #include "dynarmic/common/x64_disassemble.h"
 #include "dynarmic/interface/exclusive_monitor.h"

--- a/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
+++ b/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
@@ -471,15 +471,15 @@ void A32EmitX64::ExclusiveReadMemoryInline(A32EmitContext& ctx, IR::Inst* inst) 
 
     EmitExclusiveLock(code, conf, tmp, tmp2.cvt32());
 
+    code.mov(code.byte[r15 + offsetof(A32JitState, exclusive_state)], u8(1));
+    code.mov(tmp, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, conf.processor_id)));
+    code.mov(qword[tmp], vaddr);
+
     const auto fastmem_marker = ShouldFastmem(ctx, inst);
     if (fastmem_marker) {
         Xbyak::Label end;
 
         const auto src_ptr = r13 + vaddr;
-
-        code.mov(code.byte[r15 + offsetof(A32JitState, exclusive_state)], u8(1));
-        code.mov(tmp, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, conf.processor_id)));
-        code.mov(qword[tmp], vaddr);
 
         const auto location = code.getCurr();
         EmitReadMemoryMov<bitsize>(code, value, src_ptr);

--- a/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
+++ b/src/dynarmic/backend/x64/a32_emit_x64_memory.cpp
@@ -93,7 +93,7 @@ void A32EmitX64::GenFastmemFallbacks() {
             for (const auto& [bitsize, callback] : exclusive_write_callbacks) {
                 code.align();
                 exclusive_write_fallbacks[std::make_tuple(bitsize, vaddr_idx, value_idx)] = code.getCurr<void (*)()>();
-                ABI_PushCallerSaveRegistersAndAdjustStack(code);
+                ABI_PushCallerSaveRegistersAndAdjustStackExcept(code, HostLoc::RAX);
                 if (vaddr_idx == code.ABI_PARAM3.getIdx() && value_idx == code.ABI_PARAM2.getIdx()) {
                     code.xchg(code.ABI_PARAM2, code.ABI_PARAM3);
                 } else if (vaddr_idx == code.ABI_PARAM3.getIdx()) {
@@ -111,7 +111,7 @@ void A32EmitX64::GenFastmemFallbacks() {
                 }
                 code.mov(code.ABI_PARAM4, rax);
                 callback.EmitCall(code);
-                ABI_PopCallerSaveRegistersAndAdjustStack(code);
+                ABI_PopCallerSaveRegistersAndAdjustStackExcept(code, HostLoc::RAX);
                 code.ret();
                 PerfMapRegister(exclusive_write_fallbacks[std::make_tuple(bitsize, vaddr_idx, value_idx)], code.getCurr(), fmt::format("a32_exclusive_write_fallback_{}", bitsize));
             }
@@ -531,9 +531,9 @@ void A32EmitX64::ExclusiveWriteMemoryInline(A32EmitContext& ctx, IR::Inst* inst)
     code.mov(tmp, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, conf.processor_id)));
     code.mov(status, u32(1));
     code.cmp(code.byte[r15 + offsetof(A32JitState, exclusive_state)], u8(0));
-    code.je(end);
+    code.je(end, code.T_NEAR);
     code.cmp(qword[tmp], vaddr);
-    code.jne(end);
+    code.jne(end, code.T_NEAR);
 
     EmitExclusiveTestAndClear(code, conf, vaddr, tmp, rax);
 
@@ -582,12 +582,16 @@ void A32EmitX64::ExclusiveWriteMemoryInline(A32EmitContext& ctx, IR::Inst* inst)
                 conf.recompile_on_exclusive_fastmem_failure,
             });
 
-        code.mov(status, rax);
+        code.cmp(al, 0);
+        code.setz(status.cvt8());
+        code.movzx(status.cvt32(), status.cvt8());
         code.jmp(end, code.T_NEAR);
         code.SwitchToNearCode();
     } else {
         code.call(fallback_fn);
-        code.mov(status, rax);
+        code.cmp(al, 0);
+        code.setz(status.cvt8());
+        code.movzx(status.cvt32(), status.cvt8());
     }
 
     code.L(end);

--- a/src/dynarmic/backend/x64/a64_emit_x64.h
+++ b/src/dynarmic/backend/x64/a64_emit_x64.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <map>
+#include <optional>
 #include <tuple>
 
 #include "dynarmic/backend/x64/a64_jitstate.h"
@@ -71,6 +72,7 @@ protected:
 
     std::map<std::tuple<size_t, int, int>, void (*)()> read_fallbacks;
     std::map<std::tuple<size_t, int, int>, void (*)()> write_fallbacks;
+    std::map<int, void (*)()> exclusive_write_fallbacks;
     void GenFastmemFallbacks();
 
     const void* terminal_handler_pop_rsb_hint;
@@ -96,7 +98,7 @@ protected:
     struct FastmemPatchInfo {
         u64 resume_rip;
         u64 callback;
-        DoNotFastmemMarker marker;
+        std::optional<DoNotFastmemMarker> marker;
     };
     tsl::robin_map<u64, FastmemPatchInfo> fastmem_patch_info;
     std::set<DoNotFastmemMarker> do_not_fastmem;
@@ -112,6 +114,10 @@ protected:
     void EmitExclusiveReadMemory(A64EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
     void EmitExclusiveWriteMemory(A64EmitContext& ctx, IR::Inst* inst);
+    template<std::size_t bitsize, auto callback>
+    void EmitExclusiveReadMemoryInlineUnsafe(A64EmitContext& ctx, IR::Inst* inst);
+    template<std::size_t bitsize, auto callback>
+    void EmitExclusiveWriteMemoryInlineUnsafe(A64EmitContext& ctx, IR::Inst* inst);
 
     // Terminal instruction emitters
     void EmitTerminalImpl(IR::Term::Interpret terminal, IR::LocationDescriptor initial_location, bool is_single_step) override;

--- a/src/dynarmic/backend/x64/a64_emit_x64.h
+++ b/src/dynarmic/backend/x64/a64_emit_x64.h
@@ -99,7 +99,8 @@ protected:
     struct FastmemPatchInfo {
         u64 resume_rip;
         u64 callback;
-        std::optional<DoNotFastmemMarker> marker;
+        DoNotFastmemMarker marker;
+        bool recompile;
     };
     tsl::robin_map<u64, FastmemPatchInfo> fastmem_patch_info;
     std::set<DoNotFastmemMarker> do_not_fastmem;

--- a/src/dynarmic/backend/x64/a64_emit_x64.h
+++ b/src/dynarmic/backend/x64/a64_emit_x64.h
@@ -68,11 +68,12 @@ protected:
 
     void (*memory_read_128)();
     void (*memory_write_128)();
+    void (*memory_exclusive_write_128)();
     void GenMemory128Accessors();
 
     std::map<std::tuple<size_t, int, int>, void (*)()> read_fallbacks;
     std::map<std::tuple<size_t, int, int>, void (*)()> write_fallbacks;
-    std::map<int, void (*)()> exclusive_write_fallbacks;
+    std::map<std::tuple<size_t, int, int>, void (*)()> exclusive_write_fallbacks;
     void GenFastmemFallbacks();
 
     const void* terminal_handler_pop_rsb_hint;

--- a/src/dynarmic/backend/x64/a64_emit_x64.h
+++ b/src/dynarmic/backend/x64/a64_emit_x64.h
@@ -116,9 +116,9 @@ protected:
     template<std::size_t bitsize, auto callback>
     void EmitExclusiveWriteMemory(A64EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
-    void EmitExclusiveReadMemoryInlineUnsafe(A64EmitContext& ctx, IR::Inst* inst);
+    void EmitExclusiveReadMemoryInline(A64EmitContext& ctx, IR::Inst* inst);
     template<std::size_t bitsize, auto callback>
-    void EmitExclusiveWriteMemoryInlineUnsafe(A64EmitContext& ctx, IR::Inst* inst);
+    void EmitExclusiveWriteMemoryInline(A64EmitContext& ctx, IR::Inst* inst);
 
     // Terminal instruction emitters
     void EmitTerminalImpl(IR::Term::Interpret terminal, IR::LocationDescriptor initial_location, bool is_single_step) override;

--- a/src/dynarmic/backend/x64/a64_emit_x64_memory.cpp
+++ b/src/dynarmic/backend/x64/a64_emit_x64_memory.cpp
@@ -743,25 +743,25 @@ void A64EmitX64::EmitExclusiveWriteMemory(A64EmitContext& ctx, IR::Inst* inst) {
 
 namespace {
 
-void EmitExclusiveLock(BlockOfCode& code, const A64::UserConfig& conf, Xbyak::Reg64 ptr, Xbyak::Reg32 tmp) {
+void EmitExclusiveLock(BlockOfCode& code, const A64::UserConfig& conf, Xbyak::Reg64 pointer, Xbyak::Reg32 tmp) {
     if (conf.HasOptimization(OptimizationFlag::Unsafe_IgnoreGlobalMonitor)) {
         return;
     }
 
-    code.mov(ptr, Common::BitCast<u64>(GetExclusiveMonitorLockPointer(conf.global_monitor)));
-    EmitSpinLockLock(code, ptr, tmp);
+    code.mov(pointer, Common::BitCast<u64>(GetExclusiveMonitorLockPointer(conf.global_monitor)));
+    EmitSpinLockLock(code, pointer, tmp);
 }
 
-void EmitExclusiveUnlock(BlockOfCode& code, const A64::UserConfig& conf, Xbyak::Reg64 ptr, Xbyak::Reg32 tmp) {
+void EmitExclusiveUnlock(BlockOfCode& code, const A64::UserConfig& conf, Xbyak::Reg64 pointer, Xbyak::Reg32 tmp) {
     if (conf.HasOptimization(OptimizationFlag::Unsafe_IgnoreGlobalMonitor)) {
         return;
     }
 
-    code.mov(ptr, Common::BitCast<u64>(GetExclusiveMonitorLockPointer(conf.global_monitor)));
-    EmitSpinLockUnlock(code, ptr, tmp);
+    code.mov(pointer, Common::BitCast<u64>(GetExclusiveMonitorLockPointer(conf.global_monitor)));
+    EmitSpinLockUnlock(code, pointer, tmp);
 }
 
-void EmitExclusiveTestAndClear(BlockOfCode& code, const A64::UserConfig& conf, Xbyak::Reg64 vaddr, Xbyak::Reg64 ptr, Xbyak::Reg64 tmp) {
+void EmitExclusiveTestAndClear(BlockOfCode& code, const A64::UserConfig& conf, Xbyak::Reg64 vaddr, Xbyak::Reg64 pointer, Xbyak::Reg64 tmp) {
     if (conf.HasOptimization(OptimizationFlag::Unsafe_IgnoreGlobalMonitor)) {
         return;
     }
@@ -773,10 +773,10 @@ void EmitExclusiveTestAndClear(BlockOfCode& code, const A64::UserConfig& conf, X
             continue;
         }
         Xbyak::Label ok;
-        code.mov(ptr, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, processor_index)));
-        code.cmp(qword[ptr], vaddr);
+        code.mov(pointer, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, processor_index)));
+        code.cmp(qword[pointer], vaddr);
         code.jne(ok);
-        code.mov(qword[ptr], tmp);
+        code.mov(qword[pointer], tmp);
         code.L(ok);
     }
 }

--- a/src/dynarmic/backend/x64/a64_emit_x64_memory.cpp
+++ b/src/dynarmic/backend/x64/a64_emit_x64_memory.cpp
@@ -761,16 +761,16 @@ void A64EmitX64::EmitExclusiveReadMemoryInline(A64EmitContext& ctx, IR::Inst* in
 
     EmitExclusiveLock(code, conf, tmp, tmp2.cvt32());
 
+    code.mov(code.byte[r15 + offsetof(A64JitState, exclusive_state)], u8(1));
+    code.mov(tmp, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, conf.processor_id)));
+    code.mov(qword[tmp], vaddr);
+
     const auto fastmem_marker = ShouldFastmem(ctx, inst);
     if (fastmem_marker) {
         Xbyak::Label abort, end;
         bool require_abort_handling = false;
 
         const auto src_ptr = EmitFastmemVAddr(code, ctx, abort, vaddr, require_abort_handling);
-
-        code.mov(code.byte[r15 + offsetof(A64JitState, exclusive_state)], u8(1));
-        code.mov(tmp, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, conf.processor_id)));
-        code.mov(qword[tmp], vaddr);
 
         const auto location = code.getCurr();
         EmitReadMemoryMov<bitsize>(code, value_idx, src_ptr);

--- a/src/dynarmic/backend/x64/emit_x64_memory.h
+++ b/src/dynarmic/backend/x64/emit_x64_memory.h
@@ -1,0 +1,62 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2022 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include <xbyak/xbyak.h>
+
+#include "dynarmic/backend/x64/a64_emit_x64.h"
+#include "dynarmic/backend/x64/exclusive_monitor_friend.h"
+#include "dynarmic/common/spin_lock_x64.h"
+#include "dynarmic/interface/exclusive_monitor.h"
+
+namespace Dynarmic::Backend::X64 {
+
+namespace {
+
+using namespace Xbyak::util;
+
+template<typename UserConfig>
+void EmitExclusiveLock(BlockOfCode& code, const UserConfig& conf, Xbyak::Reg64 pointer, Xbyak::Reg32 tmp) {
+    if (conf.HasOptimization(OptimizationFlag::Unsafe_IgnoreGlobalMonitor)) {
+        return;
+    }
+
+    code.mov(pointer, Common::BitCast<u64>(GetExclusiveMonitorLockPointer(conf.global_monitor)));
+    EmitSpinLockLock(code, pointer, tmp);
+}
+
+template<typename UserConfig>
+void EmitExclusiveUnlock(BlockOfCode& code, const UserConfig& conf, Xbyak::Reg64 pointer, Xbyak::Reg32 tmp) {
+    if (conf.HasOptimization(OptimizationFlag::Unsafe_IgnoreGlobalMonitor)) {
+        return;
+    }
+
+    code.mov(pointer, Common::BitCast<u64>(GetExclusiveMonitorLockPointer(conf.global_monitor)));
+    EmitSpinLockUnlock(code, pointer, tmp);
+}
+
+template<typename UserConfig>
+void EmitExclusiveTestAndClear(BlockOfCode& code, const UserConfig& conf, Xbyak::Reg64 vaddr, Xbyak::Reg64 pointer, Xbyak::Reg64 tmp) {
+    if (conf.HasOptimization(OptimizationFlag::Unsafe_IgnoreGlobalMonitor)) {
+        return;
+    }
+
+    code.mov(tmp, 0xDEAD'DEAD'DEAD'DEAD);
+    const size_t processor_count = GetExclusiveMonitorProcessorCount(conf.global_monitor);
+    for (size_t processor_index = 0; processor_index < processor_count; processor_index++) {
+        if (processor_index == conf.processor_id) {
+            continue;
+        }
+        Xbyak::Label ok;
+        code.mov(pointer, Common::BitCast<u64>(GetExclusiveMonitorAddressPointer(conf.global_monitor, processor_index)));
+        code.cmp(qword[pointer], vaddr);
+        code.jne(ok);
+        code.mov(qword[pointer], tmp);
+        code.L(ok);
+    }
+}
+
+}  // namespace
+
+}  // namespace Dynarmic::Backend::X64

--- a/src/dynarmic/backend/x64/exclusive_monitor.cpp
+++ b/src/dynarmic/backend/x64/exclusive_monitor.cpp
@@ -21,11 +21,11 @@ size_t ExclusiveMonitor::GetProcessorCount() const {
 }
 
 void ExclusiveMonitor::Lock() {
-    while (is_locked.test_and_set(std::memory_order_acquire)) {}
+    lock.Lock();
 }
 
 void ExclusiveMonitor::Unlock() {
-    is_locked.clear(std::memory_order_release);
+    lock.Unlock();
 }
 
 bool ExclusiveMonitor::CheckAndClear(size_t processor_id, VAddr address) {

--- a/src/dynarmic/backend/x64/exclusive_monitor_friend.h
+++ b/src/dynarmic/backend/x64/exclusive_monitor_friend.h
@@ -7,6 +7,10 @@
 
 namespace Dynarmic {
 
+inline VAddr* GetExclusiveMonitorAddressPointer(ExclusiveMonitor* monitor, size_t index) {
+    return monitor->exclusive_addresses.data() + index;
+}
+
 inline Vector* GetExclusiveMonitorValuePointer(ExclusiveMonitor* monitor, size_t index) {
     return monitor->exclusive_values.data() + index;
 }

--- a/src/dynarmic/backend/x64/exclusive_monitor_friend.h
+++ b/src/dynarmic/backend/x64/exclusive_monitor_friend.h
@@ -7,6 +7,14 @@
 
 namespace Dynarmic {
 
+inline volatile int* GetExclusiveMonitorLockPointer(ExclusiveMonitor* monitor) {
+    return &monitor->lock.storage;
+}
+
+inline size_t GetExclusiveMonitorProcessorCount(ExclusiveMonitor* monitor) {
+    return monitor->exclusive_addresses.size();
+}
+
 inline VAddr* GetExclusiveMonitorAddressPointer(ExclusiveMonitor* monitor, size_t index) {
     return monitor->exclusive_addresses.data() + index;
 }

--- a/src/dynarmic/backend/x64/exclusive_monitor_friend.h
+++ b/src/dynarmic/backend/x64/exclusive_monitor_friend.h
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: 0BSD
  */
 
+#pragma once
+
 #include "dynarmic/interface/exclusive_monitor.h"
 
 namespace Dynarmic {

--- a/src/dynarmic/backend/x64/exclusive_monitor_friend.h
+++ b/src/dynarmic/backend/x64/exclusive_monitor_friend.h
@@ -1,0 +1,14 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2022 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "dynarmic/interface/exclusive_monitor.h"
+
+namespace Dynarmic {
+
+inline Vector* GetExclusiveMonitorValuePointer(ExclusiveMonitor* monitor, size_t index) {
+    return monitor->exclusive_values.data() + index;
+}
+
+}  // namespace Dynarmic

--- a/src/dynarmic/common/spin_lock.h
+++ b/src/dynarmic/common/spin_lock.h
@@ -8,32 +8,8 @@
 namespace Dynarmic {
 
 struct SpinLock {
-    void Lock() {
-        volatile int* ptr = &storage;
-        asm volatile(
-            "   jmp 2f\n"
-            "1:\n"
-            "   pause\n"
-            "2:\n"
-            "   mov $1, %%eax\n"
-            "   lock xchg %%eax, %[ptr]\n"
-            "   test %%eax, %%eax\n"
-            "   jnz 1b\n"
-            : [ptr] "=m"(*ptr)
-            : /* none */
-            : "eax", "cc", "memory");
-    }
-
-    void Unlock() {
-        volatile int* ptr = &storage;
-        asm volatile(
-            "   xor %%eax, %%eax\n"
-            "   xchg %%eax, %[ptr]\n"
-            "   mfence\n"
-            : [ptr] "=m"(*ptr)
-            : /* none */
-            : "eax", "cc", "memory");
-    }
+    void Lock();
+    void Unlock();
 
     volatile int storage;
 };

--- a/src/dynarmic/common/spin_lock.h
+++ b/src/dynarmic/common/spin_lock.h
@@ -1,0 +1,41 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2022 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#pragma once
+
+namespace Dynarmic {
+
+struct SpinLock {
+    void Lock() {
+        volatile int* ptr = &storage;
+        asm volatile(
+            "   jmp 2f\n"
+            "1:\n"
+            "   pause\n"
+            "2:\n"
+            "   mov $1, %%eax\n"
+            "   lock xchg %%eax, %[ptr]\n"
+            "   test %%eax, %%eax\n"
+            "   jnz 1b\n"
+            : [ptr] "=m"(*ptr)
+            : /* none */
+            : "eax", "cc", "memory");
+    }
+
+    void Unlock() {
+        volatile int* ptr = &storage;
+        asm volatile(
+            "   xor %%eax, %%eax\n"
+            "   xchg %%eax, %[ptr]\n"
+            "   mfence\n"
+            : [ptr] "=m"(*ptr)
+            : /* none */
+            : "eax", "cc", "memory");
+    }
+
+    volatile int storage;
+};
+
+}  // namespace Dynarmic

--- a/src/dynarmic/common/spin_lock_x64.cpp
+++ b/src/dynarmic/common/spin_lock_x64.cpp
@@ -1,0 +1,70 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2022 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "dynarmic/common/spin_lock.h"
+#include "dynarmic/backend/x64/abi.h"
+#include "dynarmic/backend/x64/hostloc.h"
+
+#include <xbyak/xbyak.h>
+
+namespace Dynarmic {
+
+void EmitSpinLockLock(Xbyak::CodeGenerator& code, Xbyak::Reg64 ptr, Xbyak::Reg32 tmp) {
+    Xbyak::Label start, loop;
+
+    code.jmp(start);
+    code.L(loop);
+    code.pause();
+    code.L(start);
+    code.mov(tmp, 1);
+    code.lock();
+    code.xchg(code.dword[ptr], tmp);
+    code.test(tmp, tmp);
+    code.jnz(loop);
+}
+
+void EmitSpinLockUnlock(Xbyak::CodeGenerator& code, Xbyak::Reg64 ptr, Xbyak::Reg32 tmp) {
+    code.xor_(tmp, tmp);
+    code.xchg(code.dword[ptr], tmp);
+    code.mfence();
+}
+
+namespace {
+
+struct SpinLockImpl {
+    SpinLockImpl();
+
+    Xbyak::CodeGenerator code;
+    void (*lock)(volatile int*);
+    void (*unlock)(volatile int*);
+};
+
+SpinLockImpl impl;
+
+SpinLockImpl::SpinLockImpl() {
+    const Xbyak::Reg64 ABI_PARAM1 = Backend::X64::HostLocToReg64(Backend::X64::ABI_PARAM1);
+
+    code.align();
+    lock = code.getCurr<void (*)(volatile int*)>();
+    EmitSpinLockLock(code, ABI_PARAM1, code.eax);
+    code.ret();
+
+    code.align();
+    unlock = code.getCurr<void (*)(volatile int*)>();
+    EmitSpinLockUnlock(code, ABI_PARAM1, code.eax);
+    code.ret();
+}
+
+}
+
+void SpinLock::Lock() {
+    impl.lock(&storage);
+}
+
+void SpinLock::Unlock() {
+    impl.unlock(&storage);
+}
+
+}  // namespace Dynarmic

--- a/src/dynarmic/common/spin_lock_x64.cpp
+++ b/src/dynarmic/common/spin_lock_x64.cpp
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: 0BSD
  */
 
-#include "dynarmic/common/spin_lock.h"
+#include <xbyak/xbyak.h>
+
 #include "dynarmic/backend/x64/abi.h"
 #include "dynarmic/backend/x64/hostloc.h"
-
-#include <xbyak/xbyak.h>
+#include "dynarmic/common/spin_lock.h"
 
 namespace Dynarmic {
 
@@ -57,7 +57,7 @@ SpinLockImpl::SpinLockImpl() {
     code.ret();
 }
 
-}
+}  // namespace
 
 void SpinLock::Lock() {
     impl.lock(&storage);

--- a/src/dynarmic/common/spin_lock_x64.h
+++ b/src/dynarmic/common/spin_lock_x64.h
@@ -1,0 +1,15 @@
+/* This file is part of the dynarmic project.
+ * Copyright (c) 2022 MerryMage
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#pragma once
+
+#include <xbyak/xbyak.h>
+
+namespace Dynarmic {
+
+void EmitSpinLockLock(Xbyak::CodeGenerator& code, Xbyak::Reg64 ptr, Xbyak::Reg32 tmp);
+void EmitSpinLockUnlock(Xbyak::CodeGenerator& code, Xbyak::Reg64 ptr, Xbyak::Reg32 tmp);
+
+}  // namespace Dynarmic

--- a/src/dynarmic/interface/A32/config.h
+++ b/src/dynarmic/interface/A32/config.h
@@ -177,6 +177,15 @@ struct UserConfig {
     /// accesses will hit the memory callbacks.
     bool recompile_on_fastmem_failure = true;
 
+    /// Determines if we should use the above fastmem_pointer for exclusive reads and
+    /// writes. On x64, dynarmic currently relies on x64 cmpxchg semantics which may not
+    /// provide fully accurate emulation.
+    bool fastmem_exclusive_access = false;
+    /// Determines if exclusive access instructions that pagefault should cause
+    /// recompilation of that block with fastmem disabled. Recompiled code will use memory
+    /// callbacks.
+    bool recompile_on_exclusive_fastmem_failure = true;
+
     // Coprocessors
     std::array<std::shared_ptr<Coprocessor>, 16> coprocessors{};
 

--- a/src/dynarmic/interface/A64/config.h
+++ b/src/dynarmic/interface/A64/config.h
@@ -254,6 +254,15 @@ struct UserConfig {
     /// This is only used if fastmem_pointer is not nullptr.
     bool silently_mirror_fastmem = true;
 
+    /// Determines if we should use the above fastmem_pointer for exclusive reads and
+    /// writes. On x64, dynarmic currently relies on x64 cmpxchg semantics which may not
+    /// provide fully accurate emulation.
+    bool fastmem_exclusive_access = false;
+    /// Determines if exclusive access instructions that pagefault should cause
+    /// recompilation of that block with fastmem disabled. Recompiled code will use memory
+    /// callbacks.
+    bool recompile_on_exclusive_fastmem_failure = true;
+
     /// This option relates to translation. Generally when we run into an unpredictable
     /// instruction the ExceptionRaised callback is called. If this is true, we define
     /// definite behaviour for some unpredictable instructions.

--- a/src/dynarmic/interface/exclusive_monitor.h
+++ b/src/dynarmic/interface/exclusive_monitor.h
@@ -71,6 +71,7 @@ private:
     void Lock();
     void Unlock();
 
+    friend VAddr* GetExclusiveMonitorAddressPointer(ExclusiveMonitor*, size_t index);
     friend Vector* GetExclusiveMonitorValuePointer(ExclusiveMonitor*, size_t index);
 
     static constexpr VAddr RESERVATION_GRANULE_MASK = 0xFFFF'FFFF'FFFF'FFFFull;

--- a/src/dynarmic/interface/exclusive_monitor.h
+++ b/src/dynarmic/interface/exclusive_monitor.h
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <vector>
 
+#include <dynarmic/common/spin_lock.h>
+
 namespace Dynarmic {
 
 using VAddr = std::uint64_t;
@@ -71,12 +73,14 @@ private:
     void Lock();
     void Unlock();
 
+    friend volatile int* GetExclusiveMonitorLockPointer(ExclusiveMonitor*);
+    friend size_t GetExclusiveMonitorProcessorCount(ExclusiveMonitor*);
     friend VAddr* GetExclusiveMonitorAddressPointer(ExclusiveMonitor*, size_t index);
     friend Vector* GetExclusiveMonitorValuePointer(ExclusiveMonitor*, size_t index);
 
     static constexpr VAddr RESERVATION_GRANULE_MASK = 0xFFFF'FFFF'FFFF'FFFFull;
     static constexpr VAddr INVALID_EXCLUSIVE_ADDRESS = 0xDEAD'DEAD'DEAD'DEADull;
-    std::atomic_flag is_locked;
+    SpinLock lock;
     std::vector<VAddr> exclusive_addresses;
     std::vector<Vector> exclusive_values;
 };

--- a/src/dynarmic/interface/exclusive_monitor.h
+++ b/src/dynarmic/interface/exclusive_monitor.h
@@ -71,6 +71,8 @@ private:
     void Lock();
     void Unlock();
 
+    friend Vector* GetExclusiveMonitorValuePointer(ExclusiveMonitor*, size_t index);
+
     static constexpr VAddr RESERVATION_GRANULE_MASK = 0xFFFF'FFFF'FFFF'FFFFull;
     static constexpr VAddr INVALID_EXCLUSIVE_ADDRESS = 0xDEAD'DEAD'DEAD'DEADull;
     std::atomic_flag is_locked;

--- a/src/dynarmic/interface/optimization_flags.h
+++ b/src/dynarmic/interface/optimization_flags.h
@@ -45,6 +45,10 @@ enum class OptimizationFlag : std::uint32_t {
     /// This is an UNSAFE optimization that causes ASIMD floating-point instructions to be run with incorrect
     /// rounding modes. This may result in inaccurate results with all floating-point ASIMD instructions.
     Unsafe_IgnoreStandardFPCRValue = 0x00080000,
+    /// This is an UNSAFE optimization that causes the global monitor to be ignored. This may
+    /// result in unexpected behaviour in multithreaded scenarios, including but not limited
+    /// to data races and deadlocks.
+    Unsafe_IgnoreGlobalMonitor = 0x00100000,
 };
 
 constexpr OptimizationFlag no_optimizations = static_cast<OptimizationFlag>(0);


### PR DESCRIPTION
This emulates exclusive instructions with qemu/unicorn semantics, relying purely on cmpxchg. Note that this will obviously suffer from the [ABA problem](https://en.wikipedia.org/wiki/ABA_problem); however no user of this library uses the exclusive callbacks correctly in order to avoid this issue anyway.