### PR TITLE
backend/arm64: implement A64SetCheckBit based on A32SetCheckBit

### DIFF
--- a/src/dynarmic/backend/arm64/emit_arm64_a64.cpp
+++ b/src/dynarmic/backend/arm64/emit_arm64_a64.cpp
@@ -20,10 +20,20 @@ using namespace oaknut::util;
 
 template<>
 void EmitIR<IR::Opcode::A64SetCheckBit>(oaknut::CodeGenerator& code, EmitContext& ctx, IR::Inst* inst) {
-    (void)code;
-    (void)ctx;
-    (void)inst;
-    ASSERT_FALSE("Unimplemented");
+    auto args = ctx.reg_alloc.GetArgumentInfo(inst);
+
+    if (args[0].IsImmediate()) {
+        if (args[0].GetImmediateU1()) {
+            code.MOV(Wscratch0, 1);
+            code.STRB(Wscratch0, SP, offsetof(StackLayout, check_bit));
+        } else {
+            code.STRB(WZR, SP, offsetof(StackLayout, check_bit));
+        }
+    } else {
+        auto Wbit = ctx.reg_alloc.ReadW(args[0]);
+        RegAlloc::Realize(Wbit);
+        code.STRB(Wbit, SP, offsetof(StackLayout, check_bit));
+    }
 }
 
 template<>


### PR DESCRIPTION
This is my first attempt on implementing a tiny function of the arm64 backend for A64.

Since the A32/x64 and A64/x64 both have an identical implementation I guessed that the arm64 backend might behave identically. In case this assumption is true, all credit for the source code goes to @MerryMage. In this assumption is false, I'd love to get some guidance to get this PR right.