### PR TITLE
backend/arm64: multi-thread safe A32AddressSpace

### DIFF
--- a/src/dynarmic/backend/arm64/a32_address_space.h
+++ b/src/dynarmic/backend/arm64/a32_address_space.h
@@ -5,6 +5,9 @@
 
 #pragma once
 
+#include <mutex>
+#include <shared_mutex>
+
 #include <mcl/stdint.hpp>
 #include <oaknut/code_block.hpp>
 #include <oaknut/oaknut.hpp>
@@ -48,6 +51,8 @@ private:
 
     tsl::robin_map<u64, CodePtr> block_entries;
     tsl::robin_map<u64, EmittedBlockInfo> block_infos;
+
+    std::shared_mutex address_space_lock{};
 
     struct PreludeInfo {
         u32* end_of_prelude;


### PR DESCRIPTION
This PR aims to make A32AddressSpace multi-thread safe from an invalidation and code emission standpoint.

Not sure if the following scenario is possible. If so, then we might need to consider a more global mutex variable.

1. Thread A: Emits a new code block "X" (thread safe)
2. Thread B: Waits for "step 1." to be completed due to the unique_lock
3. Thread B: Invalidates new code block "X" (thread safe) due to a cache invalidation
4. Thread A: Tries to run new code block "X" on host, but the block is not in memory anymore.