### PR TITLE
x64/block_of_code: Only commit minimum required memory

### DIFF
--- a/src/dynarmic/backend/x64/a32_interface.cpp
+++ b/src/dynarmic/backend/x64/a32_interface.cpp
@@ -167,6 +167,7 @@ private:
             invalidate_entire_cache = true;
             PerformCacheInvalidation();
         }
+        block_of_code.EnsureMemoryCommitted(MINIMUM_REMAINING_CODESIZE);
 
         IR::Block ir_block = A32::Translate(A32::LocationDescriptor{descriptor}, conf.callbacks, {conf.arch_version, conf.define_unpredictable_behaviour, conf.hook_hint_instructions});
         Optimization::PolyfillPass(ir_block, polyfill_options);

--- a/src/dynarmic/backend/x64/a64_interface.cpp
+++ b/src/dynarmic/backend/x64/a64_interface.cpp
@@ -270,6 +270,7 @@ private:
             invalidate_entire_cache = true;
             PerformRequestedCacheInvalidation();
         }
+        block_of_code.EnsureMemoryCommitted(MINIMUM_REMAINING_CODESIZE);
 
         // JIT Compile
         const auto get_code = [this](u64 vaddr) { return conf.callbacks->MemoryReadCode(vaddr); };

--- a/src/dynarmic/backend/x64/block_of_code.h
+++ b/src/dynarmic/backend/x64/block_of_code.h
@@ -51,6 +51,8 @@ public:
     void ClearCache();
     /// Calculates how much space is remaining to use.
     size_t SpaceRemaining() const;
+    /// Ensure at least codesize bytes of code cache memory are committed at the current code_ptr.
+    void EnsureMemoryCommitted(size_t codesize);
 
     /// Runs emulated code from code_ptr.
     HaltReason RunCode(void* jit_state, CodePtr code_ptr) const;
@@ -175,6 +177,10 @@ private:
 
     bool prelude_complete = false;
     CodePtr code_begin = nullptr;
+
+#ifdef _WIN32
+    size_t committed_size = 0;
+#endif
 
     ConstantPool constant_pool;
 

--- a/src/dynarmic/backend/x64/constant_pool.cpp
+++ b/src/dynarmic/backend/x64/constant_pool.cpp
@@ -15,6 +15,7 @@ namespace Dynarmic::Backend::X64 {
 
 ConstantPool::ConstantPool(BlockOfCode& code, size_t size)
         : code(code), insertion_point(0) {
+    code.EnsureMemoryCommitted(align_size + size);
     code.int3();
     code.align(align_size);
     pool = std::span<ConstantT>(


### PR DESCRIPTION
Reserve memory and commit in ~1MB chunks on Win32.